### PR TITLE
Don't run CI jobs for both 'push' and 'pull_request' event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ defaults:
     shell: bash
 jobs:
   test:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:
@@ -67,7 +68,9 @@ jobs:
         if: matrix.versions != 'minimal'
         run: |
           hatch run +py=${{matrix.python}} integration:test
+
   style:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Download source
@@ -104,6 +107,7 @@ jobs:
         run: hatch run lint:spelling
 
   package:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,6 +6,7 @@ on:
     - cron: '0 6 * * 6'
 jobs:
   build:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Download source


### PR DESCRIPTION
when the PR branch in the repository itself.