### PR TITLE
Suppress external warnings about mkdocs also when running as properdocs

### DIFF
--- a/properdocs/__main__.py
+++ b/properdocs/__main__.py
@@ -12,12 +12,7 @@ import warnings
 
 import click
 
-from properdocs import (
-    __version__,
-    config,
-    replacement,  # noqa: F401
-    utils,
-)
+from properdocs import __version__, config, replacement, utils
 
 if sys.platform.startswith("win"):
     try:
@@ -26,6 +21,9 @@ if sys.platform.startswith("win"):
         pass
     else:
         colorama.init()
+
+replacement.setup()
+
 
 log = logging.getLogger(__name__)
 

--- a/properdocs/replacement.py
+++ b/properdocs/replacement.py
@@ -1,7 +1,8 @@
-"""After this file is imported, all mkdocs.* imports get redirected to properdocs.* imports."""
+"""After calling setup(), all mkdocs.* imports get redirected to properdocs.* imports."""
 
 import importlib.abc
 import importlib.util
+import os
 import sys
 
 
@@ -37,6 +38,11 @@ class _AliasFinder:
         return None
 
 
-sys.meta_path.insert(0, _AliasFinder())
-# Plus, handle the topmost module directly and without waiting for it to be requested.
-sys.modules['mkdocs'] = sys.modules['properdocs']
+def setup():
+    sys.meta_path.insert(0, _AliasFinder())
+    # Plus, handle the topmost module directly and without waiting for it to be requested.
+    sys.modules['mkdocs'] = sys.modules['properdocs']
+
+    # Prevent warnings from the theme that already uses this environment variable.
+    # That warning does not apply to ProperDocs.
+    os.environ['NO_MKDOCS_2_WARNING'] = 'true'


### PR DESCRIPTION
The warning from mkdocs-material is already being suppressed for the mkdocs executable when at least 1 plugin participates.
But it is also supposed to be suppressed when running `properdocs`! This was missed.

Also rework the setup to not rely on an unused import but instead be explicit.
