### PR TITLE
docs: update theme sections and add install instructions

### DIFF
--- a/docs/user-guide/choosing-your-theme.md
+++ b/docs/user-guide/choosing-your-theme.md
@@ -4,9 +4,7 @@ Selecting and configuring a theme.
 
 ---
 
-ProperDocs includes two built-in themes ([mkdocs](#mkdocs) and
-[readthedocs](#readthedocs)), as documented below. However, many [third party
-themes] are available to choose from as well.
+ProperDocs includes two official themes ([mkdocs](#mkdocs) and [readthedocs](#readthedocs)), as documented below. Many [third party themes] are available to choose from as well.
 
 To choose a theme, set the [theme] configuration option in your `properdocs.yml`
 config file.
@@ -18,8 +16,13 @@ theme:
 
 ## mkdocs
 
-The default theme, which was built as a custom [Bootstrap] theme, supports almost
-every feature of ProperDocs.
+The `mkdocs` theme is the default official theme, built as a custom [Bootstrap] theme, and supports almost every feature of ProperDocs.
+
+Which can be installed with pip:
+
+```bash
+pip install properdocs-theme-mkdocs
+```
 
 <div id="mkdocs-theme-images" class="carousel slide carousel-fade" data-bs-ride="carousel">
   <div class="carousel-inner">
@@ -132,9 +135,13 @@ supports the following options:
 
 ## readthedocs
 
-A clone of the default theme used by the [Read the Docs] service, which offers
-the same restricted feature set as its parent theme. Like its parent theme, only
-two levels of navigation are supported.
+A clone of the default theme used by the [Read the Docs] service, which offers the same restricted feature set as its parent theme. Like its parent theme, only two levels of navigation are supported.  
+
+Which can be installed with pip:
+
+```bash
+pip install properdocs-theme-readthedocs
+```
 
 ![ReadTheDocs](../img/readthedocs.png)
 


### PR DESCRIPTION
- Updated theme sections to mark mkdocs and readthedocs as official themes
- Added separate install instructions for both themes
- Removed references to built-in themes

Closes #49