### PR TITLE
Change the environment variable that is used to suppress the nag message

### DIFF
--- a/properdocs/replacement_warning.py
+++ b/properdocs/replacement_warning.py
@@ -31,6 +31,8 @@ suddenly breaking the build of your existing site.
 To avoid these risks, switch to *ProperDocs*, a continuation of MkDocs 1.x and a drop-in replacement that supports your current MkDocs setup.
 Simply install it with `pip install properdocs` and build your site with `properdocs build` instead of the MkDocs equivalents.
 
+Alternatively, to just skip this warning in the future, you can set the environment variable `DISABLE_MKDOCS_2_WARNING=true`.
+
 For more info visit https://github.com/ProperDocs/properdocs/discussions/33 and https://properdocs.org/
 
 (This warning was initiated by one of the plugins that you depend on.)


### PR DESCRIPTION
The commit https://github.com/squidfunk/mkdocs-material/commit/51d9b76636431814df924bcda27485b16023978b made this environment unusable - it's always set and there's no reasonable way to detect whether it was actually set on the command line.

Users will unfortunately run into a new nuisance even if they previously set our variable.
