### PR TITLE
Fix toggling dark mode with `highlightjs: false` (in mkdocs theme)

### DIFF
--- a/packages/properdocs-theme-mkdocs/properdocs_theme_mkdocs/js/darkmode.js
+++ b/packages/properdocs-theme-mkdocs/properdocs_theme_mkdocs/js/darkmode.js
@@ -1,8 +1,11 @@
 function setColorMode(mode) {
     // Switch between light/dark theme. `mode` is a string value of either 'dark' or 'light'.
+    document.documentElement.setAttribute('data-bs-theme', mode);
     var hljs_light = document.getElementById('hljs-light'),
         hljs_dark = document.getElementById('hljs-dark');
-    document.documentElement.setAttribute('data-bs-theme', mode);
+    if (hljs_light == null || hljs_dark == null) {
+        return;
+    }
     if (mode == 'dark') {
         hljs_light.disabled = true;
         hljs_dark.disabled = false;


### PR DESCRIPTION
When highlightjs is disabled, some HTML elements don't exist. But the code didn't expect this and had an error, interrupting the entire action of toggling dark mode.

* Fixes https://github.com/mkdocs/mkdocs/issues/4045
